### PR TITLE
Fixed the RoboArm logo hyperlinks

### DIFF
--- a/roboarm01/observe.html
+++ b/roboarm01/observe.html
@@ -25,7 +25,7 @@
             </a>
         </div>
         <div>
-            <p class="sign-in-buttons log_in_button login_observe">Log in</p>
+            <p class="sign-in-buttons log_in_button">Log in!</p>
         </div>
 
         <div class="r_video">
@@ -50,6 +50,4 @@
             </form>
         </div>
     </div>
-</body>
-
-</html>
+</body></html>


### PR DESCRIPTION
Many people wanted to go back to the landing page from observing and main pages, but there was no way. Some of them tried clicking on the RoboArm, which is just a plain text. The main change here is that the RoboArm logo is now hyperlinked in the observe.html and main.html pages and redirects to the index.html page while clicked.

For some reason, the following commit was included in the wrong pull request and got merged with it, but it contains the main changes for this pull request: https://github.com/minerva-schools/cs162-robot-arm/pull/9/commits/fb5887d09d5e6a279ad87145c6e0c7397cb08bf9
