### PR TITLE
Adding the Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn app:app


### PR DESCRIPTION
The Procfile is an essential requirement for the application to be hosted on Heroku. It basically specifies what environment we are using and enables scaling the project easily by specifying the dyno type (dyno is basically a computing module).